### PR TITLE
Add priorities and layer masks to avoid overlap

### DIFF
--- a/data/fs25-texture-schema.json
+++ b/data/fs25-texture-schema.json
@@ -10,6 +10,8 @@
   {
     "name": "asphaltDirt",
     "count": 2
+    "count": 2,
+    "priority": 2
   },
   {
     "name": "asphaltDusty",
@@ -17,6 +19,8 @@
     "tags": { "highway": ["motorway", "trunk", "primary"] },
     "width": 8,
     "color": [70, 70, 70]
+    "color": [70, 70, 70],
+    "priority": 1
   },
   {
     "name": "asphaltGravel",
@@ -106,6 +110,8 @@
   {
     "name": "gravel",
     "count": 2
+    "count": 2,
+    "priority": 3
   },
   {
     "name": "gravelDirtMoss",

--- a/data/fs25-texture-schema.json
+++ b/data/fs25-texture-schema.json
@@ -68,7 +68,8 @@
     "name": "grass",
     "count": 2,
     "tags": { "natural": "grassland" },
-    "color": [34, 255, 34]
+    "color": [34, 255, 34],
+    "priority": 0
   },
   {
     "name": "grassClovers",

--- a/data/fs25-texture-schema.json
+++ b/data/fs25-texture-schema.json
@@ -9,7 +9,6 @@
   },
   {
     "name": "asphaltDirt",
-    "count": 2
     "count": 2,
     "priority": 2
   },
@@ -18,7 +17,6 @@
     "count": 2,
     "tags": { "highway": ["motorway", "trunk", "primary"] },
     "width": 8,
-    "color": [70, 70, 70]
     "color": [70, 70, 70],
     "priority": 1
   },
@@ -109,7 +107,6 @@
   },
   {
     "name": "gravel",
-    "count": 2
     "count": 2,
     "priority": 3
   },

--- a/maps4fs/generator/texture.py
+++ b/maps4fs/generator/texture.py
@@ -254,6 +254,7 @@ class Texture(Component):
                 continue
             if layer.priority == 0:
                 base_layer = layer
+                self.logger.debug("Found base layer %s. Postponing that to be the last layer drawn.", layer.name)
                 continue
             layer_path = layer.path(self._weights_dir)
             self.logger.debug("Drawing layer %s.", layer_path)

--- a/maps4fs/generator/texture.py
+++ b/maps4fs/generator/texture.py
@@ -251,6 +251,8 @@ class Texture(Component):
             if not layer.tags:
                 self.logger.debug("Layer %s has no tags, there's nothing to draw.", layer.name)
                 continue
+            if layer.name == "grass":
+                continue
             layer_path = layer.path(self._weights_dir)
             self.logger.debug("Drawing layer %s.", layer_path)
             img = cv2.imread(layer_path, cv2.IMREAD_UNCHANGED)
@@ -262,6 +264,14 @@ class Texture(Component):
             cumulative_image = cv2.bitwise_or(cumulative_img, output_img) # output of this will be the mask for the next layer
             cv2.imwrite(layer_path, output_img)
             self.logger.debug("Texture %s saved.", layer_path)
+        for layer in layers:
+            if layer.name == "grass":
+                layer_path = layer.path(self._weights_dir)
+                self.logger.debug("Drawing layer %s.", layer_path)
+                img = cv2.bitwise_not(cumulative_image)
+                cv2.imwrite(layer_path, img)
+                self.logger.debug("Texture %s saved.", layer_path)
+
 
     def get_relative_x(self, x: float) -> int:
         """Converts UTM X coordinate to relative X coordinate in map image.

--- a/maps4fs/generator/texture.py
+++ b/maps4fs/generator/texture.py
@@ -267,10 +267,10 @@ class Texture(Component):
         for layer in layers:
             if layer.priority == 0:
                 layer_path = layer.path(self._weights_dir)
-                self.logger.debug("Drawing layer %s.", layer_path)
+                self.logger.debug("Drawing base layer %s.", layer_path)
                 img = cv2.bitwise_not(cumulative_image)
                 cv2.imwrite(layer_path, img)
-                self.logger.debug("Texture %s saved.", layer_path)
+                self.logger.debug("Base texture %s saved.", layer_path)
 
 
     def get_relative_x(self, x: float) -> int:

--- a/maps4fs/generator/texture.py
+++ b/maps4fs/generator/texture.py
@@ -57,7 +57,7 @@ class Texture(Component):
             width: int | None = None,
             color: tuple[int, int, int] | list[int] | None = None,
             exclude_weight: bool = False,
-            priority: int | None = 999,
+            priority: int | None = 999, # TODO: Remove default of 999 when sorting with None is figured out
         ):
             self.name = name
             self.count = count
@@ -245,6 +245,7 @@ class Texture(Component):
     # pylint: disable=no-member
     def draw(self) -> None:
         """Iterates over layers and fills them with polygons from OSM data."""
+        # TODO: Add sorting with None values
         layers = sorted(self.layers, key=lambda _layer: _layer.priority)
         cumulative_image = None
         base_layer = None

--- a/maps4fs/generator/texture.py
+++ b/maps4fs/generator/texture.py
@@ -247,11 +247,13 @@ class Texture(Component):
         """Iterates over layers and fills them with polygons from OSM data."""
         layers = sorted(self.layers, key=lambda _layer: _layer.priority)
         cumulative_image = None
+        base_layer = None
         for layer in layers:
             if not layer.tags:
                 self.logger.debug("Layer %s has no tags, there's nothing to draw.", layer.name)
                 continue
             if layer.priority == 0:
+                base_layer = layer
                 continue
             layer_path = layer.path(self._weights_dir)
             self.logger.debug("Drawing layer %s.", layer_path)
@@ -264,9 +266,9 @@ class Texture(Component):
             cumulative_image = cv2.bitwise_or(cumulative_img, output_img) # output of this will be the mask for the next layer
             cv2.imwrite(layer_path, output_img)
             self.logger.debug("Texture %s saved.", layer_path)
-        for layer in layers:
-            if layer.priority == 0:
-                layer_path = layer.path(self._weights_dir)
+        if base_layer is not None:
+            if base_layer.priority == 0:
+                layer_path = base_layer.path(self._weights_dir)
                 self.logger.debug("Drawing base layer %s.", layer_path)
                 img = cv2.bitwise_not(cumulative_image)
                 cv2.imwrite(layer_path, img)

--- a/maps4fs/generator/texture.py
+++ b/maps4fs/generator/texture.py
@@ -251,7 +251,7 @@ class Texture(Component):
             if not layer.tags:
                 self.logger.debug("Layer %s has no tags, there's nothing to draw.", layer.name)
                 continue
-            if layer.name == "grass":
+            if layer.priority == 0:
                 continue
             layer_path = layer.path(self._weights_dir)
             self.logger.debug("Drawing layer %s.", layer_path)
@@ -265,7 +265,7 @@ class Texture(Component):
             cv2.imwrite(layer_path, output_img)
             self.logger.debug("Texture %s saved.", layer_path)
         for layer in layers:
-            if layer.name == "grass":
+            if layer.priority == 0:
                 layer_path = layer.path(self._weights_dir)
                 self.logger.debug("Drawing layer %s.", layer_path)
                 img = cv2.bitwise_not(cumulative_image)

--- a/maps4fs/generator/texture.py
+++ b/maps4fs/generator/texture.py
@@ -86,7 +86,7 @@ class Texture(Component):
             return data  # type: ignore
 
         @classmethod
-        def from_json(cls, data: dict[str, str | list[str] | bool ]) -> Texture.Layer:
+        def from_json(cls, data: dict[str, str | list[str] | bool]) -> Texture.Layer:
             """Creates a new instance of the class from dictionary.
 
             Args:


### PR DESCRIPTION
Adds priorities to fs25-texture-schema.json 
Implements them into texture.py to sort the order layers are drawn in
Implement a cumulative mask in texture.py#draw to minimize overlap of roads and other features

| Cyan indicates overlap |
| ---------------------- |
| Without changes        |
| ![image](https://github.com/user-attachments/assets/dfdbe207-4c5f-4123-be75-29b4dba1ed58)  |
| With changes           |
| ![image](https://github.com/user-attachments/assets/3886c772-efb0-42b9-9240-486dfe56a1e0)  |