### PR TITLE
Add troubleshooting to custom_osm.md

### DIFF
--- a/docs/custom_osm.md
+++ b/docs/custom_osm.md
@@ -41,3 +41,11 @@ If you see the error message "Download area too large", download it in parts.
 12. Save the file: **File** -> **Save as** (Ctrl + Shift + S).  
 Now, you can use this file in the generator.  
 Friendly reminder: save your file in some safe place, so you won't lose your changes. It's also recommended to use version control systems like Git to track your changes, so you can easily revert them if something goes wrong.
+
+## Troubleshooting
+If your custom OSM file is not working, throws errors or outputs a blank map try the following approach:
+1. Open your OSM file in any text editor. Search for ```action='delete'```. If there are any occurences, the file cannot be handled properly. Delete all elements that contain the action delete attribute and save the file.
+
+   Actions which could lead to this issue:
+   * **Deleting elements**. Workaround: Use **Purge** instead of **Delete** to completely remove them from the OSM file.
+   * **Combine Way** (shortcut "C") when combining two or more ways (e.g. roads) together. No workaround for now. You have to manually delete the marked elements from the OSM file.


### PR DESCRIPTION
I found more ways that could lead to a broken OSM file. I added a quick guide on how to fix it.

I wanted to combine my road segments into one long road (to have less splines in the end) but I noticed that this also leads to a broken file, because one of those two road parts gets extended but the other one gets marked as "delete".

There are probably more actions that lead to deleted elements. We can document them here and add workarounds or options how to avoid them.