### PR TITLE
USGS Provider: Fix nodata values

### DIFF
--- a/maps4fs/generator/dtm/usgs.py
+++ b/maps4fs/generator/dtm/usgs.py
@@ -34,8 +34,8 @@ class USGS1mProvider(DTMProvider):
     _author = "[ZenJakey](https://github.com/ZenJakey)"
     _is_community = True
     _instructions = (
-        "ℹ️ Set the max local elevation to approx the local max elevation for your area in meters."
-        "This will allow you to use heightScale 255 in GE with minimal tweaking. Setting this value too low can"
+        "ℹ️ Set the max local elevation to approx the local max elevation for your area in meters. "
+        "This will allow you to use heightScale 255 in GE with minimal tweaking. Setting this value too low can "
         "cause a flat map!"
     )
 

--- a/maps4fs/generator/dtm/usgs.py
+++ b/maps4fs/generator/dtm/usgs.py
@@ -34,9 +34,9 @@ class USGS1mProvider(DTMProvider):
     _author = "[ZenJakey](https://github.com/ZenJakey)"
     _is_community = True
     _instructions = (
-        "ℹ️ Set the max local elevation to approx the local max elevation for your area in meters. "
-        "This will allow you to use heightScale 255 in GE with minimal tweaking. Setting this value too low can "
-        "cause a flat map!"
+        "ℹ️ Set the max local elevation to approx the local max elevation for your area in"
+        " meters. This will allow you to use heightScale 255 in GE with minimal tweaking."
+        " Setting this value too low can cause a flat map!"
     )
 
     _url = (

--- a/maps4fs/generator/dtm/usgs.py
+++ b/maps4fs/generator/dtm/usgs.py
@@ -33,6 +33,11 @@ class USGS1mProvider(DTMProvider):
     _settings = USGS1mProviderSettings
     _author = "[ZenJakey](https://github.com/ZenJakey)"
     _is_community = True
+    _instructions = (
+        "ℹ️ Set the max local elevation to approx the local max elevation for your area in meters."
+        "This will allow you to use heightScale 255 in GE with minimal tweaking. Setting this value too low can"
+        "cause a flat map!"
+    )
 
     _url = (
         "https://tnmaccess.nationalmap.gov/api/v1/products?prodFormats=GeoTIFF,IMG&prodExtents="

--- a/maps4fs/generator/dtm/usgs.py
+++ b/maps4fs/generator/dtm/usgs.py
@@ -123,7 +123,7 @@ class USGS1mProvider(DTMProvider):
         datasets = [rasterio.open(file) for file in input_files]
 
         # Merge datasets
-        mosaic, out_transform = merge(datasets)
+        mosaic, out_transform = merge(datasets, nodata=0)
 
         # Get metadata from the first file and update it for the output
         out_meta = datasets[0].meta.copy()


### PR DESCRIPTION
Current version throws an error for a nodata value of -3.xxxe28, this fixes that (test coords 32.893474, -85.936039)
![image](https://github.com/user-attachments/assets/0330f48c-f726-4459-aa36-11e341569a91)
